### PR TITLE
refactor: move explicit start time into example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,6 +19,10 @@ module "log_analytics" {
   location            = azurerm_resource_group.example.location
 }
 
+resource "time_offset" "this" {
+  offset_days = 1
+}
+
 module "automation" {
   # source = "github.com/equinor/terraform-azurerm-automation/?ref=v0.0.0"
   source = "../.."
@@ -33,6 +37,8 @@ module "automation" {
       name        = "daily-schedule"
       description = "An example schedule that runs daily."
       frequency   = "Day"
+      start_time  = formatdate("YYYY-MM-DD'T'03:00:00Z", time_offset.this.rfc3339) # Start schedule the next day at 03:00 UTC.
+      time_zone   = "Etc/UTC"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -17,11 +17,7 @@ resource "azurerm_automation_account" "this" {
   }
 }
 
-resource "time_offset" "this" {
-  offset_days = 1
 
-  # TODO: add triggers to update time offset.
-}
 
 resource "azurerm_automation_schedule" "this" {
   for_each = var.schedules
@@ -36,9 +32,8 @@ resource "azurerm_automation_schedule" "this" {
   week_days  = each.value["week_days"]
   month_days = each.value["month_days"]
 
-  # By default, start schedule the next day at 03:00 UTC.
-  start_time = coalesce(each.value["start_time"], formatdate("YYYY-MM-DD'T'03:00:00Z", time_offset.this.rfc3339))
-  timezone   = coalesce(each.value["timezone"], "Etc/UTC")
+  start_time = each.value["start_time"]
+  timezone   = each.value["timezone"]
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "schedules" {
     week_days   = optional(list(string), null)
     month_days  = optional(list(number), null)
     start_time  = optional(string)
-    timezone    = optional(string)
+    timezone    = optional(string, "Etc/UTC")
   }))
 
   default = {}

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,5 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.39.0"
     }
-
-    time = {
-      source  = "hashicorp/time"
-      version = ">= 0.4.0"
-    }
   }
 }


### PR DESCRIPTION
Terraform dynamically sets a start time in the future anyways, so no need to do it explicitly in our module.
