### PR TITLE
feat: create runbook

### DIFF
--- a/examples/basic/Write-Hello.ps1
+++ b/examples/basic/Write-Hello.ps1
@@ -1,0 +1,6 @@
+param (
+  [Parameter(Mandatory = $false)]
+  [string]$Subject = "world"
+)
+
+Write-Output "Hello, $Subject!"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -23,3 +23,29 @@ module "automation" {
   location                   = var.location
   log_analytics_workspace_id = module.log_analytics.workspace_id
 }
+
+resource "azurerm_automation_schedule" "daily" {
+  name                    = "Daily"
+  automation_account_name = module.automation.account_name
+  resource_group_name     = var.resource_group_name
+  frequency               = "Day"
+  description             = "A schedule that runs daily."
+}
+
+module "runbook" {
+  # source = "github.com/equinor/terraform-azurerm-automation//modules/runbook?ref=v0.0.0"
+  source = "../../modules/runbook"
+
+  runbook_name        = "Write-Hello"
+  account_name        = module.automation.account_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  content             = file("${path.module}/Write-Hello.ps1")
+
+  job_schedules = {
+    "daily" = {
+      schedule_name = azurerm_automation_schedule.daily.name
+      parameters    = { "Subject" = "John Smith" }
+    }
+  }
+}

--- a/modules/runbook/main.tf
+++ b/modules/runbook/main.tf
@@ -1,0 +1,37 @@
+resource "azurerm_automation_runbook" "this" {
+  name                    = var.runbook_name
+  automation_account_name = var.account_name
+  resource_group_name     = var.resource_group_name
+  location                = var.location
+  description             = var.description
+  runbook_type            = var.runbook_type
+  content                 = var.content
+  log_verbose             = var.log_verbose
+  log_progress            = var.log_progress
+
+  tags = var.tags
+}
+
+resource "azurerm_automation_job_schedule" "this" {
+  for_each = var.job_schedules
+
+  automation_account_name = var.account_name
+  resource_group_name     = var.resource_group_name
+  runbook_name            = azurerm_automation_runbook.this.name
+  schedule_name           = each.value["schedule_name"]
+
+  # The parameter keys/names must strictly be in lowercase, even if this is not the case in the runbook.
+  # This is due to a limitation in Azure Automation where the parameter names are normalized.
+  # The values specified don't have this limitation.
+  parameters = {
+    for k, v in each.value["parameters"] : lower(k) => v
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      # Any changes to this runbook will unlink it from all schedules, i.e. delete this job schedule resource.
+      # Trigger a replace on all changes to this runbook to ensure the job schedule is always recreated in this scenario.
+      azurerm_automation_runbook.this
+    ]
+  }
+}

--- a/modules/runbook/outputs.tf
+++ b/modules/runbook/outputs.tf
@@ -1,0 +1,17 @@
+output "runbook_name" {
+  description = "The name of this Automation runbook."
+  value       = azurerm_automation_runbook.this.name
+}
+
+output "runbook_id" {
+  description = "The ID of this Automation runbook."
+  value       = azurerm_automation_runbook.this.id
+}
+
+output "job_schedule_ids" {
+  description = "A map of job schedule IDs for this Automation runbook."
+
+  value = {
+    for k, v in azurerm_automation_job_schedule.this : k => v.id
+  }
+}

--- a/modules/runbook/variables.tf
+++ b/modules/runbook/variables.tf
@@ -1,0 +1,65 @@
+variable "runbook_name" {
+  description = "The name of this Automation runbook."
+  type        = string
+}
+
+variable "account_name" {
+  description = "The name of the Automation account to create this runbook in."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group to create the resources in."
+  type        = string
+}
+
+variable "location" {
+  description = "The location to create the resources in."
+  type        = string
+}
+
+variable "content" {
+  description = "The content of this Automation runbook."
+  type        = string
+}
+
+variable "description" {
+  description = "A description for this Automation runbook."
+  type        = string
+  default     = ""
+}
+
+variable "runbook_type" {
+  description = "The type of Automation runbook to create."
+  type        = string
+  default     = "PowerShell"
+}
+
+variable "log_verbose" {
+  description = "Should verbose logs be enabled for this Automation runbook?"
+  type        = bool
+  default     = false
+}
+
+variable "log_progress" {
+  description = "Should progress logs be enabled for this Automation runbook?"
+  type        = bool
+  default     = false
+}
+
+variable "job_schedules" {
+  description = "A map of job schedules to create for this Automation runbook."
+
+  type = map(object({
+    schedule_name = string
+    parameters    = optional(map(string), {})
+  }))
+
+  default = {}
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/runbook/versions.tf
+++ b/modules/runbook/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0.0"
+    }
+  }
+}


### PR DESCRIPTION
The `runbook` submodule was previously removed in [v3.0.0](https://github.com/equinor/terraform-azurerm-automation/releases/tag/v3.0.0), however I've discovered two main reasons for re-implementing:

1. `azurerm_automation_job_schedule.this.parameters`: the parameter keys must always be defined in lowercase. I've re-implemented the logic which converts the keys to lowercase so that we don't have to deal with this issue.
1. `azurerm_automation_job_schedule.this[*]`: these resources are deleted by Azure every time we make a change to the runbook. I've added the `replace_triggered_by` lifecycle argument to force these resources to be recreated every time we make a change to the runbook, to prevent loss of these resources.

I could live with the first limitation (always specifying parameter keys in lowercase), however the second reason is quite annoying to deal with every time I update a runbook...