### PR TITLE
fix: all changes to account trigger replace of dependents

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,11 +26,6 @@ resource "azurerm_automation_account" "this" {
   tags = var.tags
 }
 
-data "azurerm_automation_account" "this" {
-  name                = azurerm_automation_account.this.name
-  resource_group_name = azurerm_automation_account.this.resource_group_name
-}
-
 resource "azurerm_monitor_diagnostic_setting" "this" {
   name                       = var.diagnostic_setting_name
   target_resource_id         = azurerm_automation_account.this.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,18 +10,10 @@ output "account_id" {
 
 output "identity_principal_id" {
   description = "The principal ID of the system-assigned identity of this Automation account."
-
-  # Get "principal_id" from a data source to read its value during the the apply phase instead of the plan phase.
-  # This ensures the Automation account system-assigned identity is always enabled before trying to read its principal ID.
-  # Ref: https://developer.hashicorp.com/terraform/language/data-sources#data-resource-behavior
-  value = try(data.azurerm_automation_account.this.identity[0].principal_id, null)
+  value       = try(azurerm_automation_account.this.identity[0].principal_id, null)
 }
 
 output "identity_tenant_id" {
   description = "The tenant ID of the system-assigned identity of this Automation account."
-
-  # Get "tenant_id" from a data source to read its value during the the apply phase instead of the plan phase.
-  # This ensures the Automation account system-assigned identity is always enabled before trying to read its tenant ID.
-  # Ref: https://developer.hashicorp.com/terraform/language/data-sources#data-resource-behavior
-  value = try(data.azurerm_automation_account.this.identity[0].tenant_id, null)
+  value       = try(azurerm_automation_account.this.identity[0].tenant_id, null)
 }


### PR DESCRIPTION
Get identity outputs directly from Automation account resource instead of data source to prevent changes to Automation account from triggering replacement of all dependent resources.